### PR TITLE
Refactor: Add explicit declaration of $ErrorView = 'NormalView' for use with PowerShell 7

### DIFF
--- a/docs/samples/test/scripts/integration/Run-IntegrationTests.ps1.sample
+++ b/docs/samples/test/scripts/integration/Run-IntegrationTests.ps1.sample
@@ -2,6 +2,7 @@
 param()
 
 $ErrorActionPreference = 'Continue'
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 
 $failedCount = 0

--- a/docs/samples/test/test.ps1.sample
+++ b/docs/samples/test/test.ps1.sample
@@ -2,6 +2,7 @@
 param()
 
 Set-StrictMode -Version Latest
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 $global:PesterDebugPreference_ShowFullErrors = $true
 

--- a/src/Invoke-PSModulePublisher.ps1
+++ b/src/Invoke-PSModulePublisher.ps1
@@ -8,6 +8,7 @@ $private:myArgs = @{
     # Repository = 'MyPSRepository'
     # DryRun = $true
 }
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 
 ################################################

--- a/templates/azure-pipelines/steps/powershell/install-publish-dependencies.yml
+++ b/templates/azure-pipelines/steps/powershell/install-publish-dependencies.yml
@@ -1,6 +1,7 @@
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     .\build\PSModulePublisher\tools\module\Install-PublishDependencies.ps1
   displayName: Install publish dependencies

--- a/templates/azure-pipelines/steps/powershell/run-build.yml
+++ b/templates/azure-pipelines/steps/powershell/run-build.yml
@@ -1,6 +1,7 @@
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     $MODULE_MANIFEST_PATH = .\build\PSModulePublisher\src\Invoke-Build.ps1
     ### Begin CI-specific code: Set job-scoped variables

--- a/templates/azure-pipelines/steps/powershell/run-publish.yml
+++ b/templates/azure-pipelines/steps/powershell/run-publish.yml
@@ -1,6 +1,7 @@
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     "PUBLISH_DRY_RUN: '$($env:PUBLISH_DRY_RUN)'" | Write-Verbose
     .\build\PSModulePublisher\src\Invoke-Publish.ps1 -ModuleManifestPath $env:MODULE_MANIFEST_PATH -Repository 'PSGallery' -DryRun:$([System.Convert]::ToBoolean($env:PUBLISH_DRY_RUN))

--- a/templates/azure-pipelines/steps/powershell/run-test.yml
+++ b/templates/azure-pipelines/steps/powershell/run-test.yml
@@ -1,6 +1,7 @@
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     .\build\PSModulePublisher\src\Invoke-Test.ps1 -ModuleManifestPath $env:MODULE_MANIFEST_PATH
   displayName: Test module via module's manifest

--- a/templates/azure-pipelines/steps/pwsh/run-build.yml
+++ b/templates/azure-pipelines/steps/pwsh/run-build.yml
@@ -1,8 +1,9 @@
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
-    $MODULE_MANIFEST_PATH = .\build\PSModulePublisher\src\Invoke-Build.ps1    
+    $MODULE_MANIFEST_PATH = .\build\PSModulePublisher\src\Invoke-Build.ps1
     ### Begin CI-specific code: Set job-scoped variables
     echo "##vso[task.setvariable variable=MODULE_MANIFEST_PATH]${MODULE_MANIFEST_PATH}"
     ### End of CI-specific code

--- a/templates/azure-pipelines/steps/pwsh/run-publish.yml
+++ b/templates/azure-pipelines/steps/pwsh/run-publish.yml
@@ -1,6 +1,7 @@
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     "PUBLISH_DRY_RUN: '$($env:PUBLISH_DRY_RUN)'" | Write-Verbose
     .\build\PSModulePublisher\src\Invoke-Publish.ps1 -ModuleManifestPath $env:MODULE_MANIFEST_PATH -Repository 'PSGallery' -DryRun:$([System.Convert]::ToBoolean($env:PUBLISH_DRY_RUN))

--- a/templates/azure-pipelines/steps/pwsh/run-test.yml
+++ b/templates/azure-pipelines/steps/pwsh/run-test.yml
@@ -1,6 +1,7 @@
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     $VerbosePreference = 'Continue'
     .\build\PSModulePublisher\src\Invoke-Test.ps1 -ModuleManifestPath $env:MODULE_MANIFEST_PATH
   displayName: Test module via module's manifest


### PR DESCRIPTION
PowerShell 7 defaults to `$ErrorView = 'ConciseView'` which can be limiting for debugging. We'll use `$ErrorView = 'NormalView'` so more details of thrown errors can be reviewed in CI logs.
