### PR TITLE
Enhancement: Install RequiredModules before generating module manifest in `Invoke-Build.ps1`

### DIFF
--- a/src/PSModulePublisher/Public/Invoke-Build.ps1
+++ b/src/PSModulePublisher/Public/Invoke-Build.ps1
@@ -13,6 +13,24 @@ try {
     "Install build dependencies" | Write-Host
     & "$PSScriptRoot\..\Private\Install-BuildDependencies.ps1"
 
+    "Install required modules" | Write-Host
+    $manifest = & $global:PROJECT['MODULE_MANIFEST_DEFINITION_FILE']
+    foreach ($m in $manifest['RequiredModules']) {
+        if ($m -is [hashtable]) {
+            $m = $m.Clone()
+            $m['Name'] = $m['ModuleName']
+            $m.Remove('ModuleName')
+        }elseif ($m -is [string]) {
+            $m = @{
+                Name = $m
+            }
+        }
+        if (!(Get-InstalledModule @m -ErrorAction SilentlyContinue)) {
+            "Installing required module: $( $m['Name'] )" | Write-Host
+            Install-Module @m -Force -Scope CurrentUser -ErrorAction Stop
+        }
+    }
+
     "Generate the module manifest" | Write-Host
     $script:manifest = & "$PSScriptRoot\..\Private\Generate-ModuleManifest.ps1" -DefinitionFile $global:PROJECT['MODULE_MANIFEST_DEFINITION_FILE'] -Path $global:PROJECT['MODULE_MANIFEST_PATH']
 


### PR DESCRIPTION
Previously , without a module's `RequiredModules` installed,`New-ModuleManifest` and `Update-ModuleManifest` will fail with an error.
- A module manifest's `RequiredModules` is a hashtable of modules that must exist on the local system before the module may be imported. See: https://stackoverflow.com/a/54348884

Now, installing required modules is done before generating the module manifest.
